### PR TITLE
Map finite parameters to ExaModels.Parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ SolverCore = "0.3"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test", "MadNLP", "NLPModelsIpopt"]
+test = ["Test", "MadNLP", "NLPModelsIpopt", "Pkg"]

--- a/src/infiniteopt_backend.jl
+++ b/src/infiniteopt_backend.jl
@@ -216,7 +216,7 @@ end
 # Check whether a mapping exists
 function _check_mapping(vref::InfiniteOpt.GeneralVariableRef, backend)
     data = backend.data
-    if !haskey(data.infvar_mappings, vref) && !haskey(data.finvar_mappings, vref)
+    if !haskey(data.infvar_mappings, vref) && !haskey(data.finvar_mappings, vref) && !haskey(data.finparam_mappings, vref)
         error("A mapping for `$vref` in the transformation backend not found.")
     end
     return
@@ -236,7 +236,8 @@ function InfiniteOpt.transformation_variable(
     _check_mapping(vref, backend)
     data = backend.data
     haskey(data.infvar_mappings, vref) && return data.infvar_mappings[vref]
-    return data.finvar_mappings[vref]
+    haskey(data.finvar_mappings, vref) && return data.finvar_mappings[vref]
+    return data.finparam_mappings[vref]
 end
 # TODO find a way to support expressions
 function InfiniteOpt.transformation_constraint(

--- a/src/infiniteopt_backend.jl
+++ b/src/infiniteopt_backend.jl
@@ -6,6 +6,7 @@ struct ExaMappingData
     infvar_mappings::Dict{InfiniteOpt.GeneralVariableRef, ExaModels.Variable}
     finvar_mappings::Dict{InfiniteOpt.GeneralVariableRef, ExaModels.Var}
     constraint_mappings::Dict{InfiniteOpt.InfOptConstraintRef, ExaModels.Constraint}
+    finparam_mappings::Dict{InfiniteOpt.GeneralVariableRef, ExaModels.Parameter}
 
     # Helpful metadata
     param_alias::Dict{InfiniteOpt.GeneralVariableRef, Symbol}
@@ -23,6 +24,7 @@ struct ExaMappingData
             Dict{InfiniteOpt.GeneralVariableRef, ExaModels.Variable}(),
             Dict{InfiniteOpt.GeneralVariableRef, ExaModels.Var}(),
             Dict{InfiniteOpt.InfOptConstraintRef, ExaModels.Constraint}(),
+            Dict{InfiniteOpt.GeneralVariableRef, ExaModels.Parameter}(),
             Dict{InfiniteOpt.GeneralVariableRef, Symbol}(),
             Symbol[],
             [],

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -787,7 +787,7 @@ function ExaModels.ExaModel(
     minimize = JuMP.objective_sense(inf_model) == _MOI.MIN_SENSE
     core = ExaModels.ExaCore(; backend = backend, minimize = minimize)
     build_exa_core!(core, data, inf_model)
-        return ExaModels.ExaModel(core)
+    return ExaModels.ExaModel(core)
 end
 function ExaModels.ExaModel(inf_model::InfiniteOpt.InfiniteModel; backend = nothing)
     return ExaModels.ExaModel(inf_model, ExaMappingData(), backend = backend)

--- a/test/finite_parameters.jl
+++ b/test/finite_parameters.jl
@@ -21,17 +21,17 @@
     xMapping = exaBackend.data.finparam_mappings[x]
     y1Mapping = exaBackend.data.finparam_mappings[y[1]]
     y2Mapping = exaBackend.data.finparam_mappings[y[2]]
-    @test xMapping isa ExaModels.Parameter{Tuple{Int64}, Int64}
-    @test y1Mapping isa ExaModels.Parameter{Tuple{Int64}, Int64}
-    @test y2Mapping isa ExaModels.Parameter{Tuple{Int64}, Int64}
+    @test xMapping isa ExaModels.Parameter{Tuple{Int}, Int}
+    @test y1Mapping isa ExaModels.Parameter{Tuple{Int}, Int}
+    @test y2Mapping isa ExaModels.Parameter{Tuple{Int}, Int}
 
     # Test finite parameter queries
     @test transformation_variable(x, exaBackend) == xMapping
     @test transformation_variable(y[1], exaBackend) == y1Mapping
     @test transformation_variable(y[2], exaBackend) == y2Mapping
-    @test InfiniteExaModels._map_variable(x, x.index_type, 0, exaData) isa ExaModels.ParameterNode{Int64}
-    @test InfiniteExaModels._map_variable(y[1], y[1].index_type, 0, exaData) isa ExaModels.ParameterNode{Int64}
-    @test InfiniteExaModels._map_variable(y[2], y[2].index_type, 0, exaData) isa ExaModels.ParameterNode{Int64}
+    @test InfiniteExaModels._map_variable(x, x.index_type, 0, exaData) isa ExaModels.ParameterNode{Int}
+    @test InfiniteExaModels._map_variable(y[1], y[1].index_type, 0, exaData) isa ExaModels.ParameterNode{Int}
+    @test InfiniteExaModels._map_variable(y[2], y[2].index_type, 0, exaData) isa ExaModels.ParameterNode{Int}
     @test length(exaModel.θ) == 3
     @test exaModel.θ[xMapping.offset + 1] == 42
     @test exaModel.θ[y1Mapping.offset + 1] == yVals[1]

--- a/test/finite_parameters.jl
+++ b/test/finite_parameters.jl
@@ -1,0 +1,39 @@
+@testset "Finite Parameters" begin
+    # Set up an InfiniteModel with finite parameters
+    yVals = [20, 30]
+    model = InfiniteModel(ExaTranscriptionBackend(NLPModelsIpopt.IpoptSolver))
+    @infinite_parameter(model, t ∈ [0, 1], num_supports = 5)
+    @finite_parameter(model, x == 42)
+    @finite_parameter(model, y[i in 1:2] == yVals[i])
+    @variable(model, 0 ≤ v ≤ 100, Infinite(t))
+
+    # Build the ExaModel backend
+    build_transformation_backend!(model, model.backend)
+    exaBackend = model.backend
+    exaData = exaBackend.data
+    exaModel = exaBackend.model
+
+    # Test finite parameter mappings
+    @test length(keys(exaBackend.data.finparam_mappings)) == 3
+    @test InfiniteExaModels._check_mapping(x, exaBackend) === nothing
+    @test InfiniteExaModels._check_mapping(y[1], exaBackend) === nothing
+    @test InfiniteExaModels._check_mapping(y[2], exaBackend) === nothing
+    xMapping = exaBackend.data.finparam_mappings[x]
+    y1Mapping = exaBackend.data.finparam_mappings[y[1]]
+    y2Mapping = exaBackend.data.finparam_mappings[y[2]]
+    @test xMapping isa ExaModels.Parameter{Tuple{Int64}, Int64}
+    @test y1Mapping isa ExaModels.Parameter{Tuple{Int64}, Int64}
+    @test y2Mapping isa ExaModels.Parameter{Tuple{Int64}, Int64}
+
+    # Test finite parameter queries
+    @test transformation_variable(x, exaBackend) == xMapping
+    @test transformation_variable(y[1], exaBackend) == y1Mapping
+    @test transformation_variable(y[2], exaBackend) == y2Mapping
+    @test InfiniteExaModels._map_variable(x, x.index_type, 0, exaData) isa ExaModels.ParameterNode{Int64}
+    @test InfiniteExaModels._map_variable(y[1], y[1].index_type, 0, exaData) isa ExaModels.ParameterNode{Int64}
+    @test InfiniteExaModels._map_variable(y[2], y[2].index_type, 0, exaData) isa ExaModels.ParameterNode{Int64}
+    @test length(exaModel.θ) == 3
+    @test exaModel.θ[xMapping.offset + 1] == 42
+    @test exaModel.θ[y1Mapping.offset + 1] == yVals[1]
+    @test exaModel.θ[y2Mapping.offset + 1] == yVals[2]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using Test, InfiniteOpt, InfiniteExaModels, MadNLP, NLPModelsIpopt, ExaModels
+import Pkg
+Pkg.add(url="https://github.com/infiniteopt/InfiniteOpt.jl/", rev="master")
 
 @test ExaTranscriptionBackend() isa ExaTranscriptionBackend
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Pkg
+import Pkg
 Pkg.add(url="https://github.com/infiniteopt/InfiniteOpt.jl/", rev="master")
 using Test, InfiniteOpt, InfiniteExaModels, MadNLP, NLPModelsIpopt, ExaModels
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
-using Test, InfiniteOpt, InfiniteExaModels, MadNLP, NLPModelsIpopt
+using Test, InfiniteOpt, InfiniteExaModels, MadNLP, NLPModelsIpopt, ExaModels
 
 @test ExaTranscriptionBackend() isa ExaTranscriptionBackend
+
+@testset "Finite Parameters" begin include("finite_parameters.jl") end
 
 # TODO add tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
-using Test, InfiniteOpt, InfiniteExaModels, MadNLP, NLPModelsIpopt, ExaModels
-import Pkg
+using Pkg
 Pkg.add(url="https://github.com/infiniteopt/InfiniteOpt.jl/", rev="master")
+using Test, InfiniteOpt, InfiniteExaModels, MadNLP, NLPModelsIpopt, ExaModels
 
 @test ExaTranscriptionBackend() isa ExaTranscriptionBackend
 


### PR DESCRIPTION
Currently, finite parameters are transcribed as scalar values and can only be updated by remaking the `ExaModel` backend from scratch. This PR makes it convenient to update finite parameter values by transcribing them as `ExaModel.Parameter`s instead, avoiding the need to remake the `ExaModel` backend.