### PR TITLE
Map parameter functions to ExaModels.Parameters

### DIFF
--- a/src/infiniteopt_backend.jl
+++ b/src/infiniteopt_backend.jl
@@ -16,7 +16,7 @@ struct ExaMappingData
     has_internal_supps::Vector{Bool}
     support_to_index::Dict{Tuple{Int, Union{Float64, Vector{Float64}}}, Int}
     semivar_info::Dict{InfiniteOpt.GeneralVariableRef, Tuple{ExaModels.Variable, Vector{Any}}}
-    pfunc_info::Dict{InfiniteOpt.GeneralVariableRef, Tuple{Symbol, <:Array}}
+    pfunc_info::Dict{InfiniteOpt.GeneralVariableRef, Tuple{Symbol, ExaModels.Parameter}}
     
     # Default constructor
     function ExaMappingData()
@@ -32,7 +32,7 @@ struct ExaMappingData
             Bool[],
             Dict{Tuple{Int, Union{Float64, Vector{Float64}}}, Int}(),
             Dict{InfiniteOpt.GeneralVariableRef, Tuple{ExaModels.Variable, Vector{Any}}}(),
-            Dict{InfiniteOpt.GeneralVariableRef, Tuple{Symbol, <:Array}}(),
+            Dict{InfiniteOpt.GeneralVariableRef, Tuple{Symbol, ExaModels.Parameter}}(),
         )
     end
 end

--- a/test/finite_parameters.jl
+++ b/test/finite_parameters.jl
@@ -43,6 +43,7 @@ end
     @infinite_parameter(model, t ∈ [0, 1], num_supports = 5)
     @variable(model, 0 ≤ v ≤ 100, Infinite(t))
     @parameter_function(model, pf == sin(t))
+    @constraint(model, c1, v + pf ≤ 100)
 
     # Build the ExaModel backend
     build_transformation_backend!(model, model.backend)
@@ -59,4 +60,9 @@ end
     @test pfuncExa.length == 5
     @test length(exaModel.θ) == 5
     @test exaModel.θ[pfuncExa.offset + 1 : pfuncExa.offset + pfuncExa.length] == sin.([0., 0.25, 0.5, 0.75, 1.0])
+
+    # Test parameter function usage in constraints
+    exaConstr = exaData.constraint_mappings[c1]
+    @test exaConstr isa ExaModels.Constraint
+    println(exaConstr)
 end


### PR DESCRIPTION
Currently, parameter functions are mapped to an array of scalar values corresponding to each of its supports. Although this array is stored in the mappings via `ExaMappingData.pfunc_info`, the values can only be properly updated by remaking the ExaModel backend from scratch. This PR makes it easier to update the scalar values by mapping them to ExaModels.Parameters instead, avoiding the need to remake the ExaModel backend.

This builds off the ExaModels.Parameter functionality developed in [#4](https://github.com/infiniteopt/InfiniteOpt.jl/pull/4).