### PR TITLE
Fix Bug with Domain Restrictions

### DIFF
--- a/src/transform.jl
+++ b/src/transform.jl
@@ -445,7 +445,7 @@ function _add_constraints(
         # Remove any elements of the iterator that violate the domain restriction
         if InfiniteOpt.has_domain_restriction(cref)
             restriction = InfiniteOpt.domain_restriction(cref)
-            filter!(i -> _support_in_restriction(restriction, i, data), itr)
+            itr = filter(i -> _support_in_restriction(restriction, i, data), itr)
         end
         # create the ExaModels expression tree based on expr
         par_src = ExaModels.ParSource()

--- a/test/transcription.jl
+++ b/test/transcription.jl
@@ -207,3 +207,12 @@ end
         @test_logs (:warn, InfiniteExaModels._ObjMeasureExpansionWarn) ExaModel(model) isa ExaModel
     end
 end
+
+@testset "Domain Restrictions" begin
+    model = InfiniteModel()
+    @infinite_parameter(model, t in [0, 1], num_supports = 10)
+    @variable(model, y, Infinite(t))
+    @constraint(model, y^2 >= 2, DomainRestrictions(t -> t >= 0.5, t))
+    @test ExaModel(model) isa ExaModel
+    @test length(ExaModel(model).cons.itr) == sum(supports(t) .>= 0.5)
+end

--- a/test/transcription.jl
+++ b/test/transcription.jl
@@ -212,7 +212,7 @@ end
     model = InfiniteModel()
     @infinite_parameter(model, t in [0, 1], num_supports = 10)
     @variable(model, y, Infinite(t))
-    @constraint(model, y^2 >= 2, DomainRestrictions(t -> t >= 0.5, t))
+    @constraint(model, y^2 >= 2, DomainRestriction(t -> t >= 0.5, t))
     @test ExaModel(model) isa ExaModel
     @test length(ExaModel(model).cons.itr) == sum(supports(t) .>= 0.5)
 end


### PR DESCRIPTION
Domain restrictions will accidently delete supports from the ExaModel because `filter!` was used instead of `filter`.